### PR TITLE
Gitmvp button and redirect

### DIFF
--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -82,6 +82,7 @@ async def process_query(
         "content_url": None,
         "error_message": None,
         "upload_failed": False,
+        "gitmvp_url": None,
     }
 
     try:
@@ -137,12 +138,17 @@ async def process_query(
             )
         return template_response(context=context)
 
+    gitmvp_url = None
+    if query.user_name and query.repo_name:
+        gitmvp_url = f"https://gitmvp.com/{query.user_name}/{query.repo_name}"
+
     context.update(
         {
             "result": True,
             "summary": summary,
             "tree": tree,
             "ingest_id": query.id if 'query' in locals() and query else None,
+            "gitmvp_url": gitmvp_url,
         }
     )
 

--- a/src/server/templates/components/result.jinja
+++ b/src/server/templates/components/result.jinja
@@ -85,6 +85,15 @@
                                 Copy Documentation Link
                             </button>
                         </div>
+                        {% if gitmvp_url %}
+                        <div class="relative inline-block group">
+                            <div class="w-full h-full rounded bg-gray-900 translate-y-1 translate-x-1 absolute inset-0"></div>
+                            <a href="{{ gitmvp_url }}" target="_blank" rel="noopener noreferrer"
+                               class="inline-flex items-center px-4 py-2 bg-[#a0e8a0] border-[3px] border-gray-900 text-gray-900 rounded group-hover:-translate-y-px group-hover:-translate-x-px transition-transform relative z-10">
+                                ✨ analyze repo
+                            </a>
+                        </div>
+                        {% endif %}
                     {% elif upload_failed %}
                          <p class="text-red-600 font-semibold">{{ error_message | default('Cloud upload failed.') }}</p>
                     {% elif content %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an "✨ analyze repo" button linking to `gitmvp.com/owner/repo` to provide a direct link for users to analyze repositories on the `gitmvp` application.

---
<p><a href="https://cursor.com/agents/bc-e3a02df1-d6f6-4a67-8500-7bb027d66dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3a02df1-d6f6-4a67-8500-7bb027d66dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->