### PR TITLE
fix: align Jinja2Templates.TemplateResponse with Starlette 0.40+ API

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -170,7 +170,7 @@ async def api_docs(request: Request) -> HTMLResponse:
     HTMLResponse
         A rendered HTML page displaying API documentation.
     """
-    return templates.TemplateResponse("api.jinja", {"request": request})
+    return templates.TemplateResponse(request, "api.jinja", {})
 
 
 @app.get("/robots.txt")

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -68,11 +68,10 @@ async def process_query(
         raise ValueError(f"Invalid pattern type: {pattern_type}")
 
     template = "index.jinja" if is_index else "git.jinja"
-    template_response = partial(templates.TemplateResponse, name=template)
+    template_response = partial(templates.TemplateResponse, request, template)
     max_file_size = log_slider_to_size(slider_position)
 
     context = {
-        "request": request,
         "repo_url": input_text,
         "examples": EXAMPLE_REPOS if is_index else [],
         "default_file_size": slider_position,

--- a/src/server/routers/dynamic.py
+++ b/src/server/routers/dynamic.py
@@ -52,9 +52,9 @@ async def catch_all(request: Request, full_path: str) -> HTMLResponse:
             loading = False
     # If not a valid repo path, just show the form with error (or fallback)
     return templates.TemplateResponse(
+        request,
         "git.jinja",
         {
-            "request": request,
             "repo_url": repo_url,
             "loading": loading,
             "default_file_size": 243,

--- a/src/server/routers/index.py
+++ b/src/server/routers/index.py
@@ -30,9 +30,9 @@ async def home(request: Request) -> HTMLResponse:
         and other default parameters such as file size.
     """
     return templates.TemplateResponse(
+        request,
         "index.jinja",
         {
-            "request": request,
             "examples": EXAMPLE_REPOS,
             "default_file_size": 243,
         },


### PR DESCRIPTION
Starlette now expects (request, name, context) instead of (name, context) with request inside the context dict. The old call order passed the context dict as the template name and caused Jinja2 to raise TypeError: unhashable type: 'dict' and HTTP 500 on rendered pages.

Update all call sites and the partial in process_query accordingly.