### PR TITLE
Fix decorative diamond positioning on landing page

### DIFF
--- a/src/server/templates/components/git_form.jinja
+++ b/src/server/templates/components/git_form.jinja
@@ -9,7 +9,7 @@
     <div class="w-full h-full absolute inset-0 bg-gray-900 rounded-xl translate-y-2 translate-x-2"></div>
     <div class="rounded-xl relative z-20 pl-8 sm:pl-10 pr-8 sm:pr-16 py-8 border-[3px] border-gray-900 bg-[#fff4da]">
         <img src="https://cdn.devdojo.com/images/january2023/shape-1.png"
-             class="absolute md:block hidden left-0 h-[4.5rem] w-[4.5rem] bottom-0 -translate-x-full ml-3">
+             class="absolute md:block hidden -left-6 bottom-4 h-[4.5rem] w-[4.5rem]">
         <form class="flex md:flex-row flex-col w-full h-full justify-center items-stretch space-y-5 md:space-y-0 md:space-x-5"
               id="ingestForm"
               onsubmit="handleSubmit(event{% if is_index %}, true{% endif %})">

--- a/src/server/templates/index.jinja
+++ b/src/server/templates/index.jinja
@@ -10,8 +10,8 @@
 {% endblock %}
 {% block content %}
     <div class="mb-8">
-        <div class="relative w-full mx-auto flex sm:flex-row flex-col justify-center items-start sm:items-center">
-            <svg class="h-auto w-16 sm:w-20 md:w-24 flex-shrink-0 p-2 md:relative sm:absolute lg:absolute left-0 lg:-translate-x-full lg:ml-32 md:translate-x-10 sm:-translate-y-16 md:-translate-y-0 -translate-x-2 lg:-translate-y-10"
+        <div class="relative w-fit max-w-full mx-auto">
+            <svg class="pointer-events-none absolute h-auto w-16 sm:w-20 md:w-24 -left-6 sm:-left-8 md:-left-10 lg:-left-12 -top-8 sm:-top-10 md:-top-4"
                  viewBox="0 0 91 98"
                  fill="none"
                  xmlns="http://www.w3.org/2000/svg">
@@ -20,12 +20,12 @@
                 <path d="M79.653 5.729c-2.436 5.323-9.515 15.25-18.341 12.374m9.197 16.336c2.6-5.851 10.008-16.834 18.842-13.956m-9.738-15.07c-.374 3.787 1.076 12.078 9.869 14.943M70.61 34.6c.503-4.21-.69-13.346-9.49-16.214M14.922 65.967c1.338 5.677 6.372 16.756 15.808 15.659M18.21 95.832c-1.392-6.226-6.54-18.404-15.984-17.305m12.85-12.892c-.41 3.771-3.576 11.588-12.968 12.681M18.025 96c.367-4.21 3.453-12.905 12.854-14" stroke="#000" stroke-width="2.548" stroke-linecap="round">
                 </path>
             </svg>
-            <h1 class="text-4xl sm:text-5xl sm:pt-20 lg:pt-5 md:text-6xl lg:text-7xl font-bold tracking-tighter w-full inline-block text-left md:text-center relative">
+            <h1 class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold tracking-tighter text-left md:text-center relative pt-10 sm:pt-12 md:pt-6">
                 Repository to
                 <br>
                 doc&nbsp;
             </h1>
-            <svg class="w-16 lg:w-20 h-auto lg:absolute flex-shrink-0 right-0 bottom-0 md:block hidden translate-y-10 md:translate-y-20 lg:translate-y-4 lg:-translate-x-12 -translate-x-10"
+            <svg class="pointer-events-none absolute w-16 lg:w-20 h-auto -right-6 sm:-right-8 md:-right-10 lg:-right-12 bottom-0 translate-y-6 md:translate-y-10 lg:translate-y-4 hidden md:block"
                  viewBox="0 0 92 80"
                  fill="none"
                  xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The red sparkle cluster beside the hero heading and the green diamond on the input card were positioned too far to the left because they were anchored to the full page width with `-translate-x-full`, which shifts them entirely outside their container.

## Changes

- **Hero (`index.jinja`)**: Wrap the heading and both sparkle SVGs in a `w-fit` container so decorations are positioned relative to the title text, with symmetric `-left-*` / `-right-*` offsets.
- **Form (`git_form.jinja`)**: Replace `-translate-x-full` on the decorative image with `-left-6 bottom-4` so it sits beside the card instead of far off-screen.

## Before / after

The left red cluster should now sit close to "Repository" in the same way the green cluster sits beside "doc", and the form decoration should no longer overlap the viewport edge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94927c1a-475c-4b74-a790-5269b0967af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94927c1a-475c-4b74-a790-5269b0967af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

